### PR TITLE
Fix minor formatting in LICENSE.txt

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -768,7 +768,7 @@ JAVA DEPENDENCIES
   https://opensource.org/licenses/MIT
 
 --------------------------------------------------------------------------------
-EXTERNAL APIs AND SERVICES
+EXTERNAL APIs AND SERVICES 
 --------------------------------------------------------------------------------
 
 This application integrates with the following external APIs. Use of these


### PR DESCRIPTION
Corrected whitespace in the 'EXTERNAL APIs AND SERVICES' section header for consistency.